### PR TITLE
support opening a file with empty path argument

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,0 +1,24 @@
+version = 1
+
+[[analyzers]]
+name = "python"
+enabled = true
+
+  [analyzers.meta]
+  runtime_version = "3.x.x"
+
+[[transformers]]
+name = "yapf"
+enabled = true
+
+[[transformers]]
+name = "isort"
+enabled = true
+
+[[transformers]]
+name = "black"
+enabled = true
+
+[[transformers]]
+name = "autopep8"
+enabled = true

--- a/plant/core.py
+++ b/plant/core.py
@@ -519,7 +519,7 @@ class Node(object):
         """
         return abspath(join(self.path, *path))
 
-    def open(self, path, *args, **kw):
+    def open(self, path=None, *args, **kw):
         """performs an :py:func:`io.open` on the given relative path to the current node.
 
         ::
@@ -539,6 +539,10 @@ class Node(object):
         :param ``*kw``: passed onto :py:func:`io.open`
         :returns: :py:class:`io.FileIO`
         """
+        if path is None and self.is_file:
+            path = ''
+        elif path is None:
+            raise TypeError('open() missing 1 required argument: path')
         return io.open(self.join(path), *args, **kw)
 
     def __repr__(self):

--- a/tests/unit/test_node.py
+++ b/tests/unit/test_node.py
@@ -31,6 +31,26 @@ def test_open(io):
     nd.open('wee.py').should.equal('an open file')
     io.open.assert_called_once_with('/foo/bar/wee.py')
 
+@patch('plant.core.io')
+def test_open_dir_with_default_path(io):
+    ("Node#open should raise error when called with default path on a dir")
+    io.open.return_value = 'an open file'
+
+    nd = Node('/foo/bar')
+
+    nd.open.when.called_with().should.throw(TypeError)
+    io.open.assert_not_called()
+
+@patch('plant.core.io')
+def test_open_file_with_default_path(io):
+    ("Node#open should default to self.path when called with default path on a file")
+    io.open.return_value = 'an open file'
+
+    nd = Node('/foo/bar.py')
+    nd.open.when.called_with().should.have.returned_the_value('an open file')
+
+    io.open.assert_called_once_with('/foo/bar.py')
+
 
 @patch('plant.core.exists')
 def test_node_path_to_related(exists):


### PR DESCRIPTION
when node is a file, we can join on path state and support calling `open` without `path` argument.
for example:
```pyhton
nd = Node('foo/bar.txt')
text = nd.open()
```
could be supported by behaving in a way similar to:
```pyhton
nd = Node('foo/bar.txt')
empty_string = ''
text = nd.open(empty_string)
```

This PR tries to support this behaviour, allowing for a node that is a file to open without providing an empty string path argument.

The PR includes required code changes and unit tests to test the behaviour described in this PR